### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/io.gitlab.guillermop.Counters.json
+++ b/io.gitlab.guillermop.Counters.json
@@ -18,17 +18,6 @@
         "--socket=fallback-x11",
         "--env=GJS_DISABLE_JIT=1"
     ],
-    "cleanup" : [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules" : [
         {
             "name" : "counters",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.